### PR TITLE
tox: use testenv tmp directory as basetemp for pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras = devel
 
 [testenv:unittests]
 commands =
-  pytest --basetemp=.pytest_tmp --cov=outpost.barbican --tb=long -vv {posargs}
+  pytest --basetemp={envtmpdir} --cov=outpost.barbican --tb=long -vv {posargs}
   coverage report -m
   coverage xml
 


### PR DESCRIPTION
Instead of hardcoded tmp dir, use tox testenv tmpdir.
There is no impact on manual call to pytest