### PR TITLE
scm: add abstract factory

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -11,7 +11,7 @@ from string import ascii_letters
 from git import Repo
 from git.exc import GitCommandError
 
-from outpost.barbican.scm import Git
+from outpost.barbican.scm.git import Git
 
 
 class GitTestBase:


### PR DESCRIPTION
This removes the circular deps between scm factory and supported scm.
This is cherry-picked from former repository