### PR TITLE
barbican: fix internal cmd import

### DIFF
--- a/src/outpost/barbican/barbican.py
+++ b/src/outpost/barbican/barbican.py
@@ -297,7 +297,7 @@ def run_internal_command(cmd: str, argv: T.List[str]) -> None:
     """
     import importlib
 
-    module = importlib.import_module("barbican._internals." + cmd)
+    module = importlib.import_module("outpost.barbican._internals." + cmd)
     module.run(argv)
 
 


### PR DESCRIPTION
This has to be renamed and i miss this one.