### PR TITLE
pyproject: fix meson dependency version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "jsonschema>=4.18.0",
     "kconfiglib>=14.1.0",
     "lief>=0.13,<0.15",
-    "meson>=1.3.0",
+    "meson>=1.4.0,<1.5.0",
     "ninja>=1.11.0",
     "ninja_syntax>1.7",
     "svd2json>=0.1.6",


### PR DESCRIPTION
meson 1.5.0 is still broken for no-std rust in C ABI library. Sanity check is broken and adds system libs as dependency even if the target is ***-none-*** which likely implies no-std support.