### PR TITLE
package,meson: add meson extra options

### DIFF
--- a/src/outpost/barbican/config.py
+++ b/src/outpost/barbican/config.py
@@ -60,7 +60,14 @@ _KERNEL_SCHEMA = json.loads(
     "type": "object",
     "properties": {
         "scm": { "$ref": "urn:barbican:scm" },
-        "config": { "type": "string" }
+        "config": { "type": "string" },
+        "build": {
+            "type": "object",
+            "properties": {
+                "options": { "$ref": "urn:barbican:build#/properties/options" }
+            },
+            "required": [ "options" ]
+        }
     },
     "required": [ "scm", "config" ],
     "additionalProperties": false
@@ -77,7 +84,14 @@ _RUNTIME_SCHEMA = json.loads(
     "type": "object",
     "properties": {
         "scm": { "$ref": "urn:barbican:scm" },
-        "config": { "type": "string" }
+        "config": { "type": "string" },
+        "build": {
+            "type": "object",
+            "properties": {
+                "options": { "$ref": "urn:barbican:build#/properties/options" }
+            },
+            "required": [ "options" ]
+        }
     },
     "required": [ "scm", "config" ],
     "additionalProperties": false

--- a/src/outpost/barbican/package/meson.py
+++ b/src/outpost/barbican/package/meson.py
@@ -18,7 +18,7 @@ class Meson(Package):
         opts.append("--pkgconfig.relocatable")
         opts.append(f"--pkg-config-path={self.pkgconfig_dir}")
         opts.append(f"-Dconfig={str(self._dotconfig)}")
-        opts.extend(self._config["build_opts"] if "build_opts" in self._config else list())
+        opts.extend([f"-D{k}={str(v)}" for k, v in self._extra_build_opts.items()])
         return opts
 
     @working_directory_attr("src_dir")

--- a/src/outpost/barbican/package/package.py
+++ b/src/outpost/barbican/package/package.py
@@ -50,6 +50,10 @@ class BackendFactoryMap(collections.abc.Mapping[Backend, collections.abc.Callabl
 class Package(ABC):
     __backend_factories: T.ClassVar[BackendFactoryMap] = BackendFactoryMap()
 
+    __built_in_options: T.ClassVar[list[str]] = [
+        "static_pie",
+    ]
+
     @unique
     class Type(StrEnum):
         """Package type enumerate."""
@@ -102,6 +106,19 @@ class Package(ABC):
 
         # XXX: Enforce path rel to project configs dir
         self._dotconfig = (Path(self._parent.path.project_dir) / dotconfig).resolve(strict=True)
+
+        self._built_in_build_opts = dict()
+        self._extra_build_opts = dict()
+        if "build" in self._config:
+            build_opts = (
+                self._config["build"]["options"] if "options" in self._config["build"] else dict()
+            )
+            self._built_in_build_opts = dict(
+                filter(lambda key: key in self.__built_in_options, build_opts.items())
+            )
+            self._extra_build_opts = dict(
+                filter(lambda key: key not in self.__built_in_options, build_opts.items())
+            )
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
build node in project.toml configuration allow user to pass barbican built-in option and/or extra options. Those options are passed using ementic name and converted by barbican according to the buildsystem backend.

E.g. w/ Meson build system

build.options.with_doc = true

-->

-Dwith_doc=True