### PR TITLE
Progress bar on git pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "tomli>=2.0.1; python_version < '3.11'",
     "referencing>=0.33.0",
     "rich>=13.6",
-    "GitPython>=3.1.43",
+    "GitPython>=3.1.44",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/outpost/barbican/scm/git.py
+++ b/src/outpost/barbican/scm/git.py
@@ -173,7 +173,7 @@ class Git(ScmBaseClass):
             if is_new_ref:
                 refspec += ":" + refspec
 
-        fetch_infos = self._repo.remote().fetch(refspec=refspec)
+        fetch_infos = self._repo.remote().fetch(refspec=refspec, progress=GitProgressBar())
 
         # this should never occurs
         if len(fetch_infos) != 1:


### PR DESCRIPTION
> Fix Fetch progress bar by @fvalette-ledger in https://github.com/gitpython-developers/GitPython/pull/1971

GitPython 3.1.44 got my fix merged, and thus, we can reintroduce progress bar on git pull (barbican update)
